### PR TITLE
Removed --type requirement from `dcdr set`

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -83,13 +83,6 @@ func (c *CLI) Commands() []climax.Command {
 					Variable: true,
 				},
 				{
-					Name:     "type",
-					Short:    "t",
-					Usage:    `--type=[boolean|percentile]`,
-					Help:     `the type of flag to set`,
-					Variable: true,
-				},
-				{
 					Name:     "value",
 					Short:    "v",
 					Usage:    `--value=0.0-1.0 or true|false`,
@@ -114,11 +107,11 @@ func (c *CLI) Commands() []climax.Command {
 
 			Examples: []climax.Example{
 				{
-					Usecase:     `-n "flag_name" -t percentile -v 0.5 -c "the flag desc"`,
+					Usecase:     `-n "flag_name" -v 0.5 -c "the flag desc"`,
 					Description: `sets a percentile flag to 50%`,
 				},
 				{
-					Usecase:     `-n "flag_name" -t boolean -v false -c "the flag desc"`,
+					Usecase:     `-n "flag_name" -v false -c "the flag desc"`,
 					Description: `sets a boolean flag to false`,
 				},
 			},

--- a/kv/client.go
+++ b/kv/client.go
@@ -133,12 +133,15 @@ func (c *Client) Set(ft *models.Feature) error {
 		if ft.Value == nil {
 			ft.Value = existing.Value
 		}
-		if ft.FeatureType != existing.FeatureType {
+		if ft.FeatureType != existing.FeatureType && ft.FeatureType != "" {
 			return TypeChangeError
+		}
+		if ft.FeatureType == "" {
+			ft.FeatureType = existing.FeatureType
 		}
 	}
 
-	bts, err = json.Marshal(ft)
+	bts, err = ft.ToJson()
 
 	err = c.Store.Put(ft.ScopedKey(), bts)
 

--- a/models/feature.go
+++ b/models/feature.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"strings"
 
@@ -58,9 +59,34 @@ func GetFeatureTypeFromValue(v interface{}) FeatureType {
 	switch v.(type) {
 	case bool:
 		return Boolean
-	default:
+	case float64, int:
 		return Percentile
+	default:
+		return Invalid
 	}
+}
+
+// GetFeatureTypeFromValue interface to type helper
+func ParseValueAndFeatureType(v string) (interface{}, FeatureType) {
+	b, err := strconv.ParseBool(v)
+
+	if err == nil && v != "0" && v != "1" {
+		return b, Boolean
+	}
+
+	f, err := strconv.ParseFloat(v, 64)
+
+	if err == nil {
+		return f, Percentile
+	}
+
+	i, err := strconv.ParseInt(v, 10, 64)
+
+	if err == nil {
+		return i, Percentile
+	}
+
+	return nil, Invalid
 }
 
 // Feature KV model for feature flags

--- a/models/feature_test.go
+++ b/models/feature_test.go
@@ -24,6 +24,15 @@ var ExpectedJSON = `{
 	}
 }`
 
+func TestGetFeatureTypeFromValue(t *testing.T) {
+	percentiles := []string{"1", "1.0", "0.0", "0", "0.5"}
+
+	for _, v := range percentiles {
+		_, ft := ParseValueAndFeatureType(v)
+		assert.Equal(t, Percentile, ft, v)
+	}
+}
+
 func TestMarshaling(t *testing.T) {
 	f := &Feature{
 		Key:         "test",


### PR DESCRIPTION
```
    Value types are now inferred from the value.
    If and invalid input is detected an error is thrown.
```
