### PR TITLE
Reload features only on SHA update

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -97,8 +97,15 @@ func (c *Client) Scopes() []string {
 	return c.scopes
 }
 
-// SetFeatureMap assigns a `FeatureMap` and merges the current scopes
+// SetFeatureMap assigns a `FeatureMap` and merges the current
+// scopes. When git is enabled a new `FeatureMap` will not be
+// assigned unless its `CurrentSha` is different from the one
+// currently found in `CurrentSha()`.
 func (c *Client) SetFeatureMap(fm *models.FeatureMap) *Client {
+	if c.config.GitEnabled() && c.CurrentSha() == fm.Dcdr.CurrentSha() {
+		return c
+	}
+
 	c.featureMap = fm
 
 	c.MergeScopes()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -208,7 +208,7 @@ func TestUpdateFeatures(t *testing.T) {
 	update := []byte(`{
 	  "dcdr": {
 		"info": {
-		  "current_sha": "abcde"
+		  "current_sha": "updated"
 		},
 		"features": {
 		  "ab": {
@@ -228,7 +228,9 @@ func TestUpdateFeatures(t *testing.T) {
 	  }
 	}`)
 
-	c := NewTestClient()
+	cfg := config.DefaultConfig()
+	cfg.Git.RepoPath = "/tmp"
+	c := New(cfg)
 	c.UpdateFeatures(json)
 
 	scoped := c.WithScopes("ab")


### PR DESCRIPTION
This one requires some explanation.

When `GitEnabled` is true we should only allow the `FeatureMap` to be updated if the incoming `CurrentSha` differs from the one currently loaded into memory. The reason for this is that when running `dcdr set` there are two writes and a read that need to take place.
1. The write of the new or updated `Feature`
2. Read back all features so that `decider.json` can be written to the repo
3. Update the `CurrentSha` 

Since the first write would cause the `dcdr watch` command to update the the internal `FeatureMap` after is is observed the `CurrentSha` would be incorrect until both the list all and update of the `CurrentSha` completed. Any HTTP clients that made requests between steps 1 and 2 would therefore receive an incorrect sha for the feature set that they would be provided.

This patch ensures that if `GitEnabled` then only reload when the SHA update has completed.
