### PR TITLE
Prevent nil values in Client:Set

### DIFF
--- a/cli/api/client.go
+++ b/cli/api/client.go
@@ -16,6 +16,7 @@ const InfoNameSpace = "info"
 
 var TypeChangeError = errors.New("cannot change existing feature types.")
 var RepoExistsError = errors.New("repository already exists")
+var NilValueError = errors.New("value cannot be nil")
 
 func KeyNotFoundError(n string) error {
 	return errors.New(fmt.Sprintf("%s not found", n))
@@ -112,6 +113,10 @@ func (c *Client) Set(ft *models.Feature) error {
 		}
 		if ft.FeatureType == "" {
 			ft.FeatureType = existing.FeatureType
+		}
+	} else {
+		if ft.Value == nil {
+			return NilValueError
 		}
 	}
 

--- a/cli/api/client_test.go
+++ b/cli/api/client_test.go
@@ -5,99 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vsco/dcdr/cli/api/stores"
 	"github.com/vsco/dcdr/cli/models"
 )
-
-type MockStore struct {
-	Item  *stores.KVByte
-	Items stores.KVBytes
-	Err   error
-}
-
-func NewMockStore(ft *models.Feature, err error) (ms *MockStore) {
-	bts, _ := ft.ToJson()
-
-	ms = &MockStore{
-		Err: err,
-	}
-
-	if ft != nil {
-		kvb := stores.KVBytes{
-			&stores.KVByte{
-				Key:   ft.Key,
-				Bytes: bts,
-			},
-		}
-
-		ms.Item = kvb[0]
-		ms.Items = kvb
-	}
-
-	return
-}
-
-func (ms *MockStore) List(prefix string) (stores.KVBytes, error) {
-	return ms.Items, ms.Err
-}
-
-func (ms *MockStore) Get(key string) (*stores.KVByte, error) {
-	return ms.Item, ms.Err
-}
-
-func (ms *MockStore) Set(key string, bts []byte) error {
-	return ms.Err
-}
-
-func (ms *MockStore) Delete(key string) error {
-	return ms.Err
-}
-
-func (ms *MockStore) Put(key string, bts []byte) error {
-	return ms.Err
-}
-
-type MockRepo struct {
-	error   error
-	sha     string
-	exists  bool
-	enabled bool
-}
-
-func (mr *MockRepo) Clone() error {
-	return mr.error
-}
-
-func (mr *MockRepo) Commit(bts []byte, msg string) error {
-	return mr.error
-}
-
-func (mr *MockRepo) Create() error {
-	return mr.error
-}
-
-func (mr *MockRepo) Exists() bool {
-	return mr.exists
-}
-
-func (mr *MockRepo) Enabled() bool {
-	return mr.enabled
-}
-
-func (mr *MockRepo) Push() error {
-	return mr.error
-}
-
-func (mr *MockRepo) Pull() error {
-	return mr.error
-}
-
-func (mr *MockRepo) CurrentSha() (string, error) {
-	return mr.sha, mr.error
-}
-
-func (mr *MockRepo) Init() {
-}
 
 func TestClientSet(t *testing.T) {
 	ft := models.NewFeature("test", 0.5, "c", "u", "s", "n")
@@ -162,6 +71,16 @@ func TestSet(t *testing.T) {
 	err := c.Set(ft)
 
 	assert.Nil(t, err)
+}
+
+func TestSetErrorOnNilValue(t *testing.T) {
+	ft := models.NewFeature("test", nil, "c", "u", "s", "n")
+	cs := NewMockStore(nil, nil)
+	c := New(cs, &MockRepo{}, "", nil)
+
+	err := c.Set(ft)
+
+	assert.Equal(t, NilValueError, err)
 }
 
 func TestTypeChangeErrorSet(t *testing.T) {

--- a/cli/api/mock_store.go
+++ b/cli/api/mock_store.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"github.com/vsco/dcdr/cli/api/stores"
+	"github.com/vsco/dcdr/cli/models"
+)
+
+type MockStore struct {
+	Item  *stores.KVByte
+	Items stores.KVBytes
+	Err   error
+}
+
+func NewMockStore(ft *models.Feature, err error) (ms *MockStore) {
+	bts, _ := ft.ToJson()
+
+	ms = &MockStore{
+		Err: err,
+	}
+
+	if ft != nil {
+		kvb := stores.KVBytes{
+			&stores.KVByte{
+				Key:   ft.Key,
+				Bytes: bts,
+			},
+		}
+
+		ms.Item = kvb[0]
+		ms.Items = kvb
+	}
+
+	return
+}
+
+func (ms *MockStore) List(prefix string) (stores.KVBytes, error) {
+	return ms.Items, ms.Err
+}
+
+func (ms *MockStore) Get(key string) (*stores.KVByte, error) {
+	return ms.Item, ms.Err
+}
+
+func (ms *MockStore) Set(key string, bts []byte) error {
+	return ms.Err
+}
+
+func (ms *MockStore) Delete(key string) error {
+	return ms.Err
+}
+
+func (ms *MockStore) Put(key string, bts []byte) error {
+	return ms.Err
+}
+
+type MockRepo struct {
+	error   error
+	sha     string
+	exists  bool
+	enabled bool
+}
+
+func (mr *MockRepo) Clone() error {
+	return mr.error
+}
+
+func (mr *MockRepo) Commit(bts []byte, msg string) error {
+	return mr.error
+}
+
+func (mr *MockRepo) Create() error {
+	return mr.error
+}
+
+func (mr *MockRepo) Exists() bool {
+	return mr.exists
+}
+
+func (mr *MockRepo) Enabled() bool {
+	return mr.enabled
+}
+
+func (mr *MockRepo) Push() error {
+	return mr.error
+}
+
+func (mr *MockRepo) Pull() error {
+	return mr.error
+}
+
+func (mr *MockRepo) CurrentSha() (string, error) {
+	return mr.sha, mr.error
+}
+
+func (mr *MockRepo) Init() {
+}

--- a/cli/api/stores/consul_store_test.go
+++ b/cli/api/stores/consul_store_test.go
@@ -3,7 +3,6 @@ package stores
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,53 +12,6 @@ var MockKVBytes = KVBytes{
 		Key:   "a",
 		Bytes: MockBytes,
 	},
-}
-
-type MockConsul struct {
-	Item  *KVByte
-	Items KVBytes
-	Err   error
-}
-
-func NewMockConsul(key string, kvb KVBytes, err error) (mc *MockConsul) {
-	mc = &MockConsul{
-		Err: err,
-	}
-
-	if len(kvb) != 0 {
-		mc.Item = kvb[0]
-		mc.Items = kvb
-	}
-
-	return
-}
-
-func (mc *MockConsul) get(key string) *api.KVPair {
-	return &api.KVPair{
-		Key:   key,
-		Value: mc.Item.Bytes,
-	}
-}
-
-func (mc *MockConsul) List(prefix string, qo *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
-	items := api.KVPairs{&api.KVPair{
-		Key:   mc.Item.Key,
-		Value: mc.Item.Bytes,
-	},
-	}
-	return items, nil, mc.Err
-}
-
-func (mc *MockConsul) Get(key string, qo *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
-	return mc.get(key), nil, mc.Err
-}
-
-func (mc *MockConsul) Put(p *api.KVPair, qo *api.WriteOptions) (*api.WriteMeta, error) {
-	return nil, mc.Err
-}
-
-func (mc *MockConsul) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
-	return nil, mc.Err
 }
 
 func TestConsulGet(t *testing.T) {

--- a/cli/api/stores/mock_consul.go
+++ b/cli/api/stores/mock_consul.go
@@ -1,0 +1,50 @@
+package stores
+
+import "github.com/hashicorp/consul/api"
+
+type MockConsul struct {
+	Item  *KVByte
+	Items KVBytes
+	Err   error
+}
+
+func NewMockConsul(key string, kvb KVBytes, err error) (mc *MockConsul) {
+	mc = &MockConsul{
+		Err: err,
+	}
+
+	if len(kvb) != 0 {
+		mc.Item = kvb[0]
+		mc.Items = kvb
+	}
+
+	return
+}
+
+func (mc *MockConsul) get(key string) *api.KVPair {
+	return &api.KVPair{
+		Key:   key,
+		Value: mc.Item.Bytes,
+	}
+}
+
+func (mc *MockConsul) List(prefix string, qo *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
+	items := api.KVPairs{&api.KVPair{
+		Key:   mc.Item.Key,
+		Value: mc.Item.Bytes,
+	},
+	}
+	return items, nil, mc.Err
+}
+
+func (mc *MockConsul) Get(key string, qo *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
+	return mc.get(key), nil, mc.Err
+}
+
+func (mc *MockConsul) Put(p *api.KVPair, qo *api.WriteOptions) (*api.WriteMeta, error) {
+	return nil, mc.Err
+}
+
+func (mc *MockConsul) Delete(key string, w *api.WriteOptions) (*api.WriteMeta, error) {
+	return nil, mc.Err
+}

--- a/cli/command_controller_test.go
+++ b/cli/command_controller_test.go
@@ -103,3 +103,23 @@ func TestListFeatures(t *testing.T) {
 
 	assert.Equal(t, Success, code)
 }
+
+func TestSet(t *testing.T) {
+	cfg := config.DefaultConfig()
+	fts := models.Features{
+		models.Feature{
+			Key:   "test",
+			Value: true,
+		},
+	}
+	c := NewMockClient(nil, fts, nil)
+	ctl := NewController(cfg, c)
+
+	ctx := climax.Context{
+		Variable: map[string]string{"name": "null-test"},
+	}
+
+	code := ctl.Set(ctx)
+
+	assert.Equal(t, Success, code)
+}


### PR DESCRIPTION
This branch prevents `nil` values from being entered into the store when no `--value` param is sent.

**_extras**_
Moved `MockStore` and `MockConsul` to their own files.
