### PR TITLE
Extract Http Caching and Helper methods

### DIFF
--- a/cli/command_controller.go
+++ b/cli/command_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vsco/dcdr/client"
 	"github.com/vsco/dcdr/config"
 	"github.com/vsco/dcdr/server"
+	"github.com/vsco/dcdr/server/middleware"
 	"github.com/zenazn/goji"
 )
 
@@ -251,6 +252,7 @@ func (cc *Controller) Serve(ctx climax.Context) int {
 	}
 
 	s := server.New(cc.Config, goji.DefaultMux, c)
+	s.Use(middleware.HTTPCachingHandler(c))
 	s.Serve()
 
 	return 0

--- a/server/handlers/features_handler.go
+++ b/server/handlers/features_handler.go
@@ -6,20 +6,28 @@ import (
 	"strings"
 
 	"github.com/vsco/dcdr/client"
+	"github.com/vsco/dcdr/client/models"
 )
 
-const DcdrScopesHeader = "x-dcdr-scopes"
-const IfNoneMatchHeader = "If-None-Match"
-const EtagHeader = "Etag"
-const ContentTypeHeader = "Content-Type"
-const CacheControlHeader = "Cache-Control"
-const PragmaHeader = "Pragma"
-const ExpiresHeader = "Expires"
-const ContentType = "application/json"
-const CacheControl = "no-cache, no-store, must-revalidate"
-const Pragma = "no-cache"
-const Expires = "0"
+const (
+	// DcdrScopesHeader comma delimited scopes to pass to the client
+	DcdrScopesHeader = "x-dcdr-scopes"
+	// ContentTypeHeader header for content type
+	ContentTypeHeader = "Content-Type"
+	// ContentType set JSON content type for responses
+	ContentType = "application/json"
+)
 
+// SetResponseHeaders set the common response headers
+func SetResponseHeaders(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(ContentTypeHeader, ContentType)
+	w.Header().Set(DcdrScopesHeader, r.Header.Get(DcdrScopesHeader))
+}
+
+// GetScopes parses the comma delimited string from DcdrScopesHeader into
+// a slice of strings.
+//
+// x-dcdr-scopes: "a/b/c, d" => []string{"a/b/c", "d"}
 func GetScopes(r *http.Request) []string {
 	scopes := strings.Split(r.Header.Get(DcdrScopesHeader), ",")
 	for i := 0; i < len(scopes); i++ {
@@ -29,39 +37,24 @@ func GetScopes(r *http.Request) []string {
 	return scopes
 }
 
-func SetResponseHeaders(w http.ResponseWriter, r *http.Request, sha string) {
-	w.Header().Set(ContentTypeHeader, ContentType)
-	w.Header().Set(EtagHeader, sha)
-	w.Header().Set(CacheControlHeader, CacheControl)
-	w.Header().Set(PragmaHeader, Pragma)
-	w.Header().Set(ExpiresHeader, Expires)
-	w.Header().Set(DcdrScopesHeader, r.Header.Get(DcdrScopesHeader))
+// ScopeMapFromRequest helper method for returning a FeatureMap scoped to
+// the values found in DcdrScopesHeader.
+func ScopeMapFromRequest(c client.ClientIFace, r *http.Request) *models.FeatureMap {
+	return c.WithScopes(GetScopes(r)...).ScopedMap()
 }
 
-func NotModified(sha string, r *http.Request) bool {
-	if v := r.Header.Get(IfNoneMatchHeader); v != "" && sha != "" {
-		return sha == r.Header.Get(IfNoneMatchHeader)
-	}
-
-	return false
-}
-
+// FeaturesHandler default handler for serving a FeatureMap via HTTP
 func FeaturesHandler(c client.ClientIFace) func(
 	w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if NotModified(c.CurrentSha(), r) {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-
-		json, err := c.WithScopes(GetScopes(r)...).ScopedMap().ToJson()
+		json, err := ScopeMapFromRequest(c, r).ToJson()
 
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		SetResponseHeaders(w, r, c.CurrentSha())
+		SetResponseHeaders(w, r)
 		w.Write(json)
 	}
 }

--- a/server/middleware/http_caching_handler.go
+++ b/server/middleware/http_caching_handler.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/vsco/dcdr/client"
+	"github.com/zenazn/goji/web"
+)
+
+const (
+	// IfNoneMatchHeader http header containing the clients CurrentSha
+	IfNoneMatchHeader = "If-None-Match"
+	// EtagHeader header used to pass the CurrentSha in responses
+	EtagHeader = "Etag"
+	// CacheControlHeader sets the caches control header for the response
+	CacheControlHeader = "Cache-Control"
+	// PragmaHeader sets the pragma header for the response
+	PragmaHeader = "Pragma"
+	// ExpiresHeader sets the expires header for the response
+	ExpiresHeader = "Expires"
+	// CacheControl ensure no client-side caching
+	CacheControl = "no-cache, no-store, must-revalidate"
+	// Pragma ensure no client-side caching
+	Pragma = "no-cache"
+	// Expires ensure no client-side caching
+	Expires = "0"
+)
+
+// NotModified checks the requests If-None-Match header for a matching
+// CurrentSha in the Client.
+func NotModified(sha string, r *http.Request) bool {
+	if v := r.Header.Get(IfNoneMatchHeader); v != "" && sha != "" {
+		return sha == r.Header.Get(IfNoneMatchHeader)
+	}
+
+	return false
+}
+
+// SetCacheHeaders ensure response is not cached on the client.
+// Caching should be done using the Etag and If-None-Match headers.
+func SetCacheHeaders(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(CacheControlHeader, CacheControl)
+	w.Header().Set(PragmaHeader, Pragma)
+	w.Header().Set(ExpiresHeader, Expires)
+}
+
+// HTTPCachingHandle middleware that provides HTTP level caching
+// using the If-None-Match header. If the value of this header contains
+// a matching CurrentSha this handler will write a 304 status and return.
+func HTTPCachingHandler(dcdr client.ClientIFace) func(*web.C, http.Handler) http.Handler {
+	return func(c *web.C, h http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			if sha := dcdr.CurrentSha(); sha != "" {
+				w.Header().Set(EtagHeader, sha)
+			}
+
+			SetCacheHeaders(w, r)
+
+			if NotModified(dcdr.CurrentSha(), r) {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			h.ServeHTTP(w, r)
+		}
+
+		return http.HandlerFunc(fn)
+	}
+}

--- a/server/middleware/http_caching_handler_test.go
+++ b/server/middleware/http_caching_handler_test.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/vsco/dcdr/client"
+	"github.com/vsco/dcdr/client/models"
+	"github.com/vsco/dcdr/config"
+	http_assert "github.com/vsco/goji-test/assert"
+	"github.com/vsco/goji-test/builder"
+	"github.com/zenazn/goji"
+	"github.com/zenazn/goji/web"
+)
+
+func TestHTTPCaching(t *testing.T) {
+	cfg := config.TestConfig()
+	fm := models.EmptyFeatureMap()
+	fm.Dcdr.Info.CurrentSha = "current-sha"
+	dcdr := client.New(cfg).SetFeatureMap(fm)
+	mux := goji.DefaultMux
+
+	mux.Get("/", func(c web.C, w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mux.Use(HTTPCachingHandler(dcdr))
+
+	resp := builder.WithMux(mux).
+		Get("/").
+		Header(IfNoneMatchHeader, fm.Dcdr.Info.CurrentSha).Do()
+
+	http_assert.Response(t, resp.Response).
+		HasStatusCode(http.StatusNotModified).
+		ContainsHeaderValue(EtagHeader, fm.Dcdr.CurrentSha()).
+		ContainsHeaderValue(CacheControlHeader, CacheControl).
+		ContainsHeaderValue(PragmaHeader, Pragma).
+		ContainsHeaderValue(ExpiresHeader, Expires)
+
+	resp = builder.WithMux(mux).
+		Get("/").
+		Header(IfNoneMatchHeader, "").Do()
+
+	http_assert.Response(t, resp.Response).
+		HasStatusCode(http.StatusOK).
+		ContainsHeaderValue(EtagHeader, fm.Dcdr.CurrentSha()).
+		ContainsHeaderValue(CacheControlHeader, CacheControl).
+		ContainsHeaderValue(PragmaHeader, Pragma).
+		ContainsHeaderValue(ExpiresHeader, Expires)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vsco/dcdr/client"
 	"github.com/vsco/dcdr/config"
 	"github.com/vsco/dcdr/server/handlers"
+	"github.com/vsco/dcdr/server/middleware"
 	"github.com/zenazn/goji"
 	"github.com/zenazn/goji/graceful"
 	"github.com/zenazn/goji/web"
@@ -41,6 +42,7 @@ func NewDefault() (srv *server) {
 	}
 
 	srv = New(cfg, goji.DefaultMux, client)
+	srv.Use(middleware.HTTPCachingHandler(client))
 
 	return
 }


### PR DESCRIPTION
 This branch extracts a HTTPCachingHandler from the caching
  logic in FeatureHandler. This middleware is now used in
  `server.NewDefault`. I also moved scoped map retrieval to
  a helper method so that non-default server implementations
  can use this logic more easily.
