### PR TITLE
Fix race in Watcher/Client loading

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ func New(cfg *config.Config) (c *Client) {
 		}
 
 		c.watcher = watcher.NewWatcher(c.config.Watcher.OutputPath)
-		printer.Say("started watching %s", c.config.Watcher.OutputPath)
+		printer.Logf("started watching %s", c.config.Watcher.OutputPath)
 	}
 
 	return
@@ -229,6 +229,9 @@ func (c *Client) Watch() (*Client, error) {
 		}
 
 		c.watcher.Register(c.UpdateFeatures)
+
+		// Load initial values into `FeatureMap`
+		c.watcher.Updated()
 		go c.watcher.Watch()
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,7 +2,10 @@ package client
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
+
+	"io/ioutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vsco/dcdr/client/models"
@@ -216,4 +219,22 @@ func TestUpdateFeatures(t *testing.T) {
 	assert.Equal(t, float64(0.3), scoped.Features()["float"])
 	assert.True(t, scoped.FeatureExists("new_ab_feature"))
 	assert.Equal(t, true, scoped.Features()["default_bool"])
+}
+
+func TestWatch(t *testing.T) {
+	p := "/tmp/decider.json"
+	fm, err := models.NewFeatureMap(JSONBytes)
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(p, JSONBytes, 0644)
+	assert.NoError(t, err)
+
+	cfg := config.DefaultConfig()
+	cfg.Watcher.OutputPath = p
+	c := New(cfg)
+	c.Watch()
+
+	assert.Equal(t, fm, c.FeatureMap())
+
+	err = os.Remove(p)
+	assert.NoError(t, err)
 }

--- a/client/watcher/watcher_test.go
+++ b/client/watcher/watcher_test.go
@@ -34,20 +34,12 @@ func TestNewWatcher(t *testing.T) {
 	assert.NoError(t, err)
 
 	var wg sync.WaitGroup
-	wg.Add(2)
-
-	updateCount := 0
+	wg.Add(1)
 
 	w.Register(func(bts []byte) {
-		if updateCount == 0 {
-			// check original bytes when watch is started
-			assert.Equal(t, fmt.Sprintf("%s", origBytes), fmt.Sprintf("%s", bts))
-		} else {
-			// check updated bytes on write
-			assert.Equal(t, fmt.Sprintf("%s", updatedBytes), fmt.Sprintf("%s", bts))
-		}
+		// check updated bytes on write
+		assert.Equal(t, fmt.Sprintf("%s", updatedBytes), fmt.Sprintf("%s", bts))
 
-		updateCount++
 		wg.Done()
 	})
 


### PR DESCRIPTION
  In some cases decider would not have time
  to load features from disk before being used. now
  we call Updated as soon as Watch begins.
