### PR TITLE
Store and send the last modified key date

### DIFF
--- a/cli/api/client.go
+++ b/cli/api/client.go
@@ -9,6 +9,8 @@ import (
 
 	"encoding/json"
 
+	"time"
+
 	"github.com/PagerDuty/godspeed"
 	"github.com/vsco/dcdr/cli/api/stores"
 	"github.com/vsco/dcdr/cli/printer"
@@ -291,7 +293,8 @@ func (c *Client) UpdateCurrentSHA() (string, error) {
 	key := fmt.Sprintf("%s/%s", c.Namespace(), InfoNameSpace)
 
 	info := &models.Info{
-		CurrentSHA: sha,
+		CurrentSHA:       sha,
+		LastModifiedDate: time.Now().UTC().Unix(),
 	}
 
 	bts, err := json.Marshal(info)
@@ -383,7 +386,7 @@ func (c *Client) KVsToFeatureMap(kvb stores.KVBytes) (*models.FeatureMap, error)
 				return fm, err
 			}
 
-			fm.Dcdr.Info = info
+			fm.Dcdr.Info = &info
 		} else {
 			var ft models.Feature
 			err := json.Unmarshal(v.Bytes, &ft)

--- a/client/client.go
+++ b/client/client.go
@@ -24,7 +24,7 @@ type IFace interface {
 	SetFeatureMap(fm *models.FeatureMap) *Client
 	ScopedMap() *models.FeatureMap
 	Scopes() []string
-	CurrentSHA() string
+	Info() *models.Info
 	WithScopes(scopes ...string) *Client
 }
 
@@ -108,7 +108,7 @@ func (c *Client) Scopes() []string {
 // assigned unless its `CurrentSHA` is different from the one
 // currently found in `CurrentSHA()`.
 func (c *Client) SetFeatureMap(fm *models.FeatureMap) *Client {
-	if c.config.GitEnabled() && c.CurrentSHA() == fm.Dcdr.CurrentSHA() {
+	if c.config.GitEnabled() && c.Info().CurrentSHA == fm.Dcdr.CurrentSHA() {
 		return c
 	}
 
@@ -143,9 +143,9 @@ func (c *Client) Features() models.FeatureScopes {
 	return c.features
 }
 
-// CurrentSHA accessor for the underlying `CurrentSHA` from `FeatureMap`
-func (c *Client) CurrentSHA() string {
-	return c.FeatureMap().Dcdr.CurrentSHA()
+// Info accessor for the underlying `Info` from `FeatureMap`
+func (c *Client) Info() *models.Info {
+	return c.FeatureMap().Dcdr.Info
 }
 
 // FeatureExists checks the existence of a key

--- a/models/feature_map.go
+++ b/models/feature_map.go
@@ -17,7 +17,8 @@ type FeatureMap struct {
 
 // Info contains the metadata for the current `FeatureMap`.
 type Info struct {
-	CurrentSHA string `json:"current_sha,omitempty"`
+	CurrentSHA       string `json:"current_sha,omitempty"`
+	LastModifiedDate int64  `json:"last_modfied_date,omitempty"`
 }
 
 // FeatureScopes the map of percentile and boolean K/Vs.
@@ -26,7 +27,7 @@ type FeatureScopes map[string]interface{}
 // Root wrapper struct for `Info` and `Features`.
 type Root struct {
 	sync.RWMutex
-	Info          Info          `json:"info"`
+	Info          *Info         `json:"info"`
 	FeatureScopes FeatureScopes `json:"features"`
 }
 
@@ -34,7 +35,7 @@ type Root struct {
 func EmptyFeatureMap() (fm *FeatureMap) {
 	fm = &FeatureMap{
 		Dcdr: Root{
-			Info: Info{
+			Info: &Info{
 				CurrentSHA: "",
 			},
 			FeatureScopes: FeatureScopes{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,6 +6,8 @@ import (
 
 	"bytes"
 
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vsco/dcdr/client"
 	"github.com/vsco/dcdr/config"
@@ -83,8 +85,10 @@ func TestGetScopes(t *testing.T) {
 
 func TestHTTPCaching(t *testing.T) {
 	srv := mockServer()
+	ts := time.Now().Unix()
 	fm := models.EmptyFeatureMap()
 	fm.Dcdr.Info.CurrentSHA = "current-sha"
+	fm.Dcdr.Info.LastModifiedDate = ts
 	srv.Client.SetFeatureMap(fm)
 
 	resp := builder.WithMux(srv).
@@ -94,6 +98,7 @@ func TestHTTPCaching(t *testing.T) {
 	http_assert.Response(t, resp.Response).
 		HasStatusCode(http.StatusNotModified).
 		ContainsHeaderValue(middleware.EtagHeader, fm.Dcdr.CurrentSHA()).
+		ContainsHeaderValue(middleware.LastModifiedHeader, time.Unix(ts, 0).Format(time.RFC1123)).
 		ContainsHeaderValue(middleware.CacheControlHeader, middleware.CacheControl).
 		ContainsHeaderValue(middleware.PragmaHeader, middleware.Pragma).
 		ContainsHeaderValue(middleware.ExpiresHeader, middleware.Expires)


### PR DESCRIPTION
Currently we send the the `CurrentSHA` of the backing stores `FeatureMap` and return it to clients in the `Etag` header. This caching strategy works for most clients but in the wild we have observed old etags being received so clients do not update their feature sets. This could be from poor ISP caching or some other weirdness. Adding this functionality will allow client to reason about if the key set from the server is going backward in time without breaking the HTTP caching mechanism.

This branch adds a `LastModifiedDate` to the `Info` struct that is set on each update to the backing store. This value is sent as the `Last-Modified` header from the Decider server. `LastModifiedDate` is a unix timestamp with minute resolution as that is what is allowed by the RFC1123 date format.