### PR TITLE
avoid stat on non-existent file with dcdr_mock

### DIFF
--- a/client/mock/mock_client.go
+++ b/client/mock/mock_client.go
@@ -8,7 +8,11 @@ import (
 
 // New creates a `Client` with an empty `FeatureMap` and `Config`.
 func New() (d *Client) {
-	c, _ := client.New(&config.Config{})
+	c, _ := client.New(&config.Config{
+		Watcher: config.Watcher{
+			OutputPath: "",
+		},
+	})
 
 	d = &Client{
 		Client:     *c,


### PR DESCRIPTION
Does the mock actually need to have this output path filled with the default value somewhere else?

Setting it to empty avoids build failures like this one:
https://travis-ci.com/vsco/media/builds/25382744

My builds are failing just from calling `config.Mock()`

