### PR TITLE
Scope helpers

### DIFF
--- a/server/demo/main.go
+++ b/server/demo/main.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/vsco/dcdr/client"
 	"github.com/vsco/dcdr/server"
+	"github.com/vsco/dcdr/server/handlers"
 )
 
 const AuthorizationHeader = "Authorization"
 const CountryCodeHeader = "X-Country"
-const DcdrScopesHeader = "x-dcdr-scopes"
 
 // MockAuth example authentication middleware.
 // Checks for any value in the http Authorization header.
@@ -33,16 +33,14 @@ func MockAuth(c client.IFace) func(http.Handler) http.Handler {
 	}
 }
 
+// ScopedCountryCode appends the country-codes/xx scope as the X-Country header
 func ScopedCountryCode(c client.IFace) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			cc := strings.ToLower(r.Header.Get(CountryCodeHeader))
 
 			if cc != "" {
-				// Check for existing scopes and append 'country-code/xx'
-				scopes := strings.Split(r.Header.Get(DcdrScopesHeader), ",")
-				scopes = append(scopes, fmt.Sprintf("country-codes/%s", cc))
-				r.Header.Set(DcdrScopesHeader, strings.Join(scopes, ","))
+				handlers.AppendScope(r, fmt.Sprintf("country-codes/%s", cc))
 			}
 
 			h.ServeHTTP(w, r)

--- a/server/handlers/features_handler.go
+++ b/server/handlers/features_handler.go
@@ -58,6 +58,19 @@ func GetScopes(r *http.Request) []string {
 	return deduped
 }
 
+// AppendScope adds a scope to the `x-dcdr-scopes` header
+func AppendScope(r *http.Request, scope string) {
+	scopes := GetScopes(r)
+	scopes = append(scopes, scope)
+
+	SetScopes(r, scopes)
+}
+
+// SetScopes joins the values from scopes and sets the scopes header
+func SetScopes(r *http.Request, scopes []string) {
+	r.Header.Set(DcdrScopesHeader, strings.Join(scopes, ","))
+}
+
 // ScopeMapFromRequest helper method for returning a FeatureMap scoped to
 // the values found in DcdrScopesHeader.
 func ScopeMapFromRequest(c client.IFace, r *http.Request) *models.FeatureMap {

--- a/server/handlers/features_handler_test.go
+++ b/server/handlers/features_handler_test.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func R() *http.Request {
+	r, _ := http.NewRequest("GET", "http://:9191/", bytes.NewReader([]byte{}))
+	return r
+}
+
+func TestGetScopes(t *testing.T) {
+	r := R()
+	r.Header.Set(DcdrScopesHeader, " a,b, c")
+
+	assert.Equal(t, []string{"a", "b", "c"}, GetScopes(r))
+}
+
+func TestSetScopes(t *testing.T) {
+	r := R()
+	scopes := []string{"d", "e"}
+	SetScopes(r, scopes)
+
+	assert.Equal(t, scopes, GetScopes(r))
+}
+
+func TestAppendScope(t *testing.T) {
+	r := R()
+	scope := "d"
+	r.Header.Set(DcdrScopesHeader, "a/b/c")
+	AppendScope(r, scope)
+
+	assert.Equal(t, []string{"a/b/c", scope}, GetScopes(r))
+}


### PR DESCRIPTION
Adding helpers for for setting and appending scopes.

```Go
AppendScope(r *http.Request, scope string)
SetScopes(r *http.Request, scopes []string) 
```