### PR TITLE
Add SetPercentileFeature to the client mock

### DIFF
--- a/client/mock/mock_client.go
+++ b/client/mock/mock_client.go
@@ -41,16 +41,20 @@ func (d *Client) DisableBoolFeature(feature string) {
 	d.MergeScopes()
 }
 
+// SetPercentileFeature set a percentile feature to an arbitrary value
+func (d *Client) SetPercentileFeature(feature string, val float64) {
+	d.Client.FeatureMap().Dcdr.Defaults()[feature] = val
+	d.MergeScopes()
+}
+
 // EnablePercentileFeature set a percentile feature to true
 func (d *Client) EnablePercentileFeature(feature string) {
-	d.Client.FeatureMap().Dcdr.Defaults()[feature] = 1.0
-	d.MergeScopes()
+	d.SetPercentileFeature(feature, 1.0)
 }
 
 // DisablePercentileFeature set a percentile feature to false
 func (d *Client) DisablePercentileFeature(feature string) {
-	d.Client.FeatureMap().Dcdr.Defaults()[feature] = 0.0
-	d.MergeScopes()
+	d.SetPercentileFeature(feature, 0.0)
 }
 
 // Watch noop for tests.

--- a/client/mock/mock_client_test.go
+++ b/client/mock/mock_client_test.go
@@ -14,6 +14,8 @@ func TestMockClient(t *testing.T) {
 	d.DisableBoolFeature("bool")
 	assert.False(t, d.IsAvailable("bool"))
 
+	d.SetPercentileFeature("float", 0.2)
+	assert.Equal(t, 2.0, d.ScaleValue("float", 0, 10))
 	d.EnablePercentileFeature("float")
 	assert.True(t, d.IsAvailableForID("float", 2))
 	d.DisablePercentileFeature("float")


### PR DESCRIPTION
Additional method for easier mocking of percentile values.