### PR TITLE
exposes a sample limit param on the statter interfacer

### DIFF
--- a/client/stats/godspeed/godspeed_statter.go
+++ b/client/stats/godspeed/godspeed_statter.go
@@ -18,8 +18,8 @@ func New(gs *godspeed.Godspeed, tags []string) (g *Godspeed) {
 }
 
 // Incr increments a key.
-func (g *Godspeed) Incr(key string) {
-	g.gs.Incr(key, g.tags)
+func (g *Godspeed) Incr(key string, sampleRate float64) {
+	g.gs.Send(key, "c", 1, sampleRate, g.tags)
 }
 
 // Tags accessor for `tags`.

--- a/client/stats/stats.go
+++ b/client/stats/stats.go
@@ -1,7 +1,7 @@
 package stats
 
 type IFace interface {
-	Incr(feature string)
+	Incr(feature string, sampleRate float64)
 	Tags() []string
 }
 

--- a/client/stats_client.go
+++ b/client/stats_client.go
@@ -49,7 +49,7 @@ func NewStatsDefault(stats stats.IFace) (sc *StatsClient, err error) {
 // IsAvailable delegates `IsAvailable` and increments the provided `feature` status.
 func (sc *StatsClient) IsAvailable(feature string) bool {
 	enabled := sc.Client.IsAvailable(feature)
-	defer sc.Incr(feature, enabled)
+	defer sc.Incr(feature, enabled, 1)
 
 	return enabled
 }
@@ -57,7 +57,7 @@ func (sc *StatsClient) IsAvailable(feature string) bool {
 // IsAvailableForID delegates `IsAvailableForID` and increments the provided `feature` status.
 func (sc *StatsClient) IsAvailableForID(feature string, id uint64) bool {
 	enabled := sc.Client.IsAvailableForID(feature, id)
-	defer sc.Incr(feature, enabled)
+	defer sc.Incr(feature, enabled, 1)
 
 	return enabled
 }
@@ -88,9 +88,9 @@ func (sc *StatsClient) Scopes() []string {
 }
 
 // Incr increments the formatted `statKey`.
-func (sc *StatsClient) Incr(feature string, enabled bool) {
+func (sc *StatsClient) Incr(feature string, enabled bool, sampleRate float64) {
 	key := sc.statKey(feature, enabled)
-	sc.stats.Incr(key)
+	sc.stats.Incr(key, sampleRate)
 }
 
 func (sc *StatsClient) statKey(feature string, enabled bool) string {

--- a/client/stats_client_test.go
+++ b/client/stats_client_test.go
@@ -15,7 +15,7 @@ type MockStatter struct {
 	Count map[string]int
 }
 
-func (ms *MockStatter) Incr(key string) {
+func (ms *MockStatter) Incr(key string, sampleRate float64) {
 	ms.Count[key]++
 }
 


### PR DESCRIPTION
Changes the `stats.Statter` interface to expose a "sample rate" param. This allows for downsampling of stats in hot codepaths. 

Datadog docs: 
http://docs.datadoghq.com/guides/metrics/#sample-rates