### PR TITLE
Travis builds now push Docker images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,17 @@ env:
   global:
   - GOPATH=$HOME/go
 
+before_install:
+  - if test -n "$DOCKER_REGISTRY" ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" "$DOCKER_REGISTRY" ; fi
 install:
   - script/bootstrap
 script:
   - script/test
   - script/build-image
+after_success:
+  - '([ "${TRAVIS_PULL_REQUEST}" != "false" ] || script/docker-tag-and-push "${DOCKER_REPO:-dcdr}" ${TRAVIS_BRANCH})'
+  - '([ "${TRAVIS_PULL_REQUEST}"  = "false" ] || script/docker-tag-and-push "${DOCKER_REPO:-dcdr}" ${TRAVIS_PULL_REQUEST})'
+  - 'script/docker-tag-and-push "${DOCKER_REPO:-dcdr}" ${TRAVIS_COMMIT}'
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ env:
   - GOPATH=$HOME/go
 
 before_install:
+  # If you want your Travis CI build to push images to a Docker repository,
+  # define these for environment variables in your Travis CI settings for the
+  # repository:
+  # - DOCKER_REGISTRY  private registry to push to
+  # - DOCKER_USERNAME  username at the registry
+  # - DOCKER_PASSWORD  the registry password for DOCKER_USERNAME
+  # - DOCKER_REPO      repo to push to
   - if test -n "$DOCKER_REGISTRY" ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" "$DOCKER_REGISTRY" ; fi
 install:
   - script/bootstrap

--- a/script/build-image
+++ b/script/build-image
@@ -3,4 +3,4 @@ set -e
 
 cd $(dirname $0)/..
 ./script/build
-docker build -f Dockerfile.archlinux -t dcdr .
+docker build -f Dockerfile.archlinux -t "${DOCKER_REPO:-dcdr}" .

--- a/script/docker-tag-and-push
+++ b/script/docker-tag-and-push
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Usage: script/docker-tag-and-push SERVICE TAG
+# Example: script/docker-tag-and-push dcdr 12345
+
+echo_err() {
+  echo $@ >> /dev/stderr
+}
+
+usage() {
+  echo_err "usage: $0 SERVICE TAG"
+  exit 1
+}
+
+run_or_sudo() {
+  $@ || sudo $@
+}
+
+tag_and_push() {
+  set +x
+  local service="$1"
+  local commitish="$2"
+
+  [ -z "${service}" ] && {
+    echo_err "fatal: no service present."
+    usage
+  }
+  [ -z "${commitish}" ] && {
+    echo_err "fatal: no commit present, failing to tag."
+    usage
+  }
+  set -x
+  run_or_sudo docker tag "${service}" ${DOCKER_REGISTRY}/${service}:${commitish}
+  run_or_sudo docker push ${DOCKER_REGISTRY}/${service}:${commitish}
+}
+
+if test -n "$DOCKER_REGISTRY" ; then
+  tag_and_push $1 $2
+fi


### PR DESCRIPTION
@vsco/devops @vsco/platform In order to work with our deployment workflow, dcdr needs to push images from the CI build.