### PR TITLE
Attempt to add debugging for feature map update errors

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -187,7 +187,7 @@ func (c *Client) UpdateFeatures(bts []byte) {
 	fm, err := models.NewFeatureMap(bts)
 
 	if err != nil {
-		printer.SayErr("parse error: %v", err)
+		printer.SayErr("parse error: %v, feature payload: %s", err, bts)
 		return
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -164,7 +164,7 @@ func TestCrc32(t *testing.T) {
 }
 
 func TestUpdateFeatures(t *testing.T) {
-	json := []byte(`{
+	raw := []byte(`{
 	  "dcdr": {
 		"info": {
 		  "current_sha": "abcde"
@@ -212,7 +212,7 @@ func TestUpdateFeatures(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Git.RepoPath = "/tmp"
 	c, _ := New(cfg)
-	c.UpdateFeatures(json)
+	c.UpdateFeatures(raw)
 
 	scoped := c.WithScopes("ab")
 
@@ -225,6 +225,20 @@ func TestUpdateFeatures(t *testing.T) {
 	assert.Equal(t, float64(0.3), scoped.Features()["float"])
 	assert.True(t, scoped.FeatureExists("new_ab_feature"))
 	assert.Equal(t, true, scoped.Features()["default_bool"])
+}
+
+func TestClient_UpdateFeatures_Failure(t *testing.T) {
+	badUpdate := []byte(`{
+	  "dcdr": {
+		"info": {
+		  "current_sha": "abcde"
+		},`)
+
+	cfg := config.DefaultConfig()
+	cfg.Git.RepoPath = "/tmp"
+	c, _ := New(cfg)
+	c.UpdateFeatures(badUpdate)
+	assert.EqualValues(t, models.EmptyFeatureMap(), c.FeatureMap(), "Assert bad payload returns empty feature map")
 }
 
 func TestWatch(t *testing.T) {


### PR DESCRIPTION
Running into some errors with JSON decoding from Consul updates, this will help get to the bottom of it.

* fix package collision
* [dcdr error] parse error: unexpected end of JSON input
* Attempting to see why the watcher (consul) is firing before completion