### PR TITLE
Remove redundant `features` variable

### DIFF
--- a/client/mock/mock_client.go
+++ b/client/mock/mock_client.go
@@ -26,8 +26,7 @@ func New() (d *Client) {
 // Client mock `Client` for testing.
 type Client struct {
 	client.Client
-	featureMap *models.FeatureMap
-	features   models.FeatureScopes
+	featureMap *models.FeatureMap	
 }
 
 // EnableBoolFeature set a boolean feature to true
@@ -60,7 +59,7 @@ func (d *Client) DisablePercentileFeature(feature string) {
 
 // Features `features` accessor
 func (d *Client) Features() models.FeatureScopes {
-	return d.features
+	return d.Client.FeatureMap().Dcdr.Defaults()
 }
 
 // Watch noop for tests.

--- a/client/mock/mock_client.go
+++ b/client/mock/mock_client.go
@@ -26,7 +26,7 @@ func New() (d *Client) {
 // Client mock `Client` for testing.
 type Client struct {
 	client.Client
-	featureMap *models.FeatureMap	
+	featureMap *models.FeatureMap
 }
 
 // EnableBoolFeature set a boolean feature to true


### PR DESCRIPTION
Fixes the `Features()` function, to return the correct FeatureScopes