### PR TITLE
Fixing docker-compose setup to include git repo

### DIFF
--- a/compose_config/config.hcl
+++ b/compose_config/config.hcl
@@ -1,0 +1,22 @@
+
+Username = "dcdr_admin"
+Namespace = "dcdr"
+Storage = "consul"
+
+Consul {
+	 Address = "consul:8500"
+ }
+
+Watcher {
+   OutputPath = "/etc/dcdr/decider.json"
+}
+
+Server {
+   JsonRoot = "dcdr"
+   Endpoint = "/dcdr.json"
+}
+
+Git {
+   RepoURL = "file:///etc/dcdr/git-backup"
+   RepoPath = "/etc/dcdr/audit"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   dcdr_watch:
     environment:
       - "CONSUL_HTTP_ADDR=consul:8500"
+      - GIT_AUTHOR_NAME=User1
+      - GIT_AUTHOR_EMAIL=user@example.com
+      - GIT_COMMITTER_NAME=User1
+      - GIT_COMMITTER_EMAIL=user@example.com
     build:
       dockerfile: Dockerfile
       context: .
@@ -10,29 +14,34 @@ services:
     links:
       - consul:consul
     volumes:
-      - "/etc/dcdr:/etc/dcdr"
+      - "./compose_config:/etc/dcdr"
     image: dcdr
   dcdr_server:
     environment:
       - "CONSUL_HTTP_ADDR=consul:8500"
+      - GIT_AUTHOR_NAME=User1
+      - GIT_AUTHOR_EMAIL=user@example.com
+      - GIT_COMMITTER_NAME=User1
+      - GIT_COMMITTER_EMAIL=user@example.com
+
     build:
       dockerfile: Dockerfile
       context: .
     command: server
     ports:
-      - "9000:9000"
+      - "8000"
     links:
       - consul:consul
     depends_on:
       - consul
     volumes:
-      - "/etc/dcdr:/etc/dcdr"
+      - "./compose_config:/etc/dcdr"
     image: dcdr
   consul:
     image: progrium/consul:latest
     ports:
-      - "9400:8400"
-      - "9500:8500"
-      - "9600:53/udp"
+      - "8400"
+      - "8500"
+      - "53/udp"
     hostname: node1
     command: -server -bootstrap

--- a/script/compose
+++ b/script/compose
@@ -3,5 +3,20 @@
 set -e
 
 cd $(dirname $0)/..
+
+rm -Rf compose_config/git-backup compose_config/audit
+
+mkdir compose_config/git-backup
+cd compose_config/git-backup
+git init --bare
+
+TEMP_WORK_DIR=`mktemp -d`
+git --work-tree=${TEMP_WORK_DIR} checkout --orphan master
+touch ${TEMP_WORK_DIR}/decider.json
+git --work-tree=${TEMP_WORK_DIR} add ${TEMP_WORK_DIR}/decider.json
+git --work-tree=${TEMP_WORK_DIR} commit -a --allow-empty -m "empty repo"
+
+cd -
+
 docker-compose build
-docker-compose up
+docker-compose up -d


### PR DESCRIPTION
I found it a bit trickey to configure the git setup
So I've documented into the docker-compose setup.

Now out of the box, you can have git configured with a local file based repo

```bash
root@0f0a7a8e59a0:/go/src/github.com/vsco/dcdr# cat /etc/dcdr/decider.json
{
  "dcdr": {
    "info": {
      "current_sha": "65e3b58fe63c9d5ba0d521fd0e5a0afbdea8385a",
      "last_modfied_date": 1520836148
    },
    "features": {
      "default": {
        "test1": true
      }
    }
  }
```