### PR TITLE
Test Forked Travis for VSCO Docker Login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 language: go
-go: 1.8
+go: 1.9
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   # - DOCKER_USERNAME  username at the registry
   # - DOCKER_PASSWORD  the registry password for DOCKER_USERNAME
   # - DOCKER_REPO      repo to push to
+  - env | grep DOCKER | grep -v PASSWORD
   - if test -n "$DOCKER_REGISTRY" ; then docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" "$DOCKER_REGISTRY" ; fi
 install:
   - script/bootstrap


### PR DESCRIPTION
feat: bump go to 1.9

Saw some issues in a forked PR where it seems like `docker login` was failing, testing on a PR from a forked repo.