### PR TITLE
Fixes for the test to run on windows

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,6 +24,14 @@ func NewTestClient() (c *Client) {
 	return
 }
 
+func TempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "dcdr")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir error: %s", err.Error())
+	}
+	return dir
+}
+
 var JSONBytes = []byte(`{
   "dcdr": {
     "features": {
@@ -210,10 +218,8 @@ func TestUpdateFeatures(t *testing.T) {
 	}`)
 
 	cfg := config.DefaultConfig()
-	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	dir := TempDir(t)
+	defer os.RemoveAll(dir)
 	cfg.Git.RepoPath = dir
 	c, _ := New(cfg)
 	c.UpdateFeatures(raw)
@@ -239,10 +245,8 @@ func TestClient_UpdateFeatures_Failure(t *testing.T) {
 		},`)
 
 	cfg := config.DefaultConfig()
-	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	dir := TempDir(t)
+	defer os.RemoveAll(dir)
 	cfg.Git.RepoPath = dir
 	c, _ := New(cfg)
 	c.UpdateFeatures(badUpdate)
@@ -250,7 +254,7 @@ func TestClient_UpdateFeatures_Failure(t *testing.T) {
 }
 
 func TestWatch(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := ioutil.TempFile(os.TempDir(), "dcdr.json")
 	p := tmpfile.Name()
 	fm, err := models.NewFeatureMap(JSONBytes)
 	assert.NoError(t, err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -210,7 +210,11 @@ func TestUpdateFeatures(t *testing.T) {
 	}`)
 
 	cfg := config.DefaultConfig()
-	cfg.Git.RepoPath = "/tmp"
+	dir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.Git.RepoPath = dir
 	c, _ := New(cfg)
 	c.UpdateFeatures(raw)
 
@@ -235,14 +239,19 @@ func TestClient_UpdateFeatures_Failure(t *testing.T) {
 		},`)
 
 	cfg := config.DefaultConfig()
-	cfg.Git.RepoPath = "/tmp"
+	dir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.Git.RepoPath = dir
 	c, _ := New(cfg)
 	c.UpdateFeatures(badUpdate)
 	assert.EqualValues(t, models.EmptyFeatureMap(), c.FeatureMap(), "Assert bad payload returns empty feature map")
 }
 
 func TestWatch(t *testing.T) {
-	p := "/tmp/decider.json"
+	tmpfile, err := ioutil.TempFile("", "example")
+	p := tmpfile.Name()
 	fm, err := models.NewFeatureMap(JSONBytes)
 	assert.NoError(t, err)
 	err = ioutil.WriteFile(p, JSONBytes, 0644)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TempDir(t *testing.T) string {
+	dir, err := ioutil.TempDir(os.TempDir(), "dcdr")
+	if err != nil {
+		t.Fatalf("ioutil.TempDir error: %s", err.Error())
+	}
+	return dir
+}
+
 func TestDefaultConfig(t *testing.T) {
 	ConfigDir = "/tmp/does/not/exist"
 	cfg := LoadConfig()
@@ -43,9 +51,7 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestEnvOverride(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	assert.NoError(t, err)
-
+	dir := TempDir(t)
 	defer os.RemoveAll(dir)
 
 	os.Setenv(envConfigDirOverride, dir)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os/user"
 	"testing"
 
+	"io/ioutil"
+
 	"os"
 
 	"fmt"
@@ -41,7 +43,12 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestEnvOverride(t *testing.T) {
-	os.Setenv(envConfigDirOverride, "/tmp/dcdr")
+	dir, err := ioutil.TempDir("", "example")
+	assert.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	os.Setenv(envConfigDirOverride, dir)
 	cfg := LoadConfig()
 
 	assert.Equal(t, Path(), fmt.Sprintf("%s/%s", os.Getenv(envConfigDirOverride), configFileName))


### PR DESCRIPTION
Utilize OS specific temp directories/files rather than relying on `/tmp`