### PR TITLE
Watch parent directory

### DIFF
--- a/cli/api/client_test.go
+++ b/cli/api/client_test.go
@@ -137,9 +137,9 @@ func TestKVsToFeatureMapInfoExistByNameSpace(t *testing.T) {
 	}
 
 	cs := stores.NewMockStore(nil, nil)
-	config := config.DefaultConfig()
-	config.Namespace = "diffrent_namespace"
-	c := New(cs, &stores.MockRepo{}, config, nil)
+	cfg := config.DefaultConfig()
+	cfg.Namespace = "diffrent_namespace"
+	c := New(cs, &stores.MockRepo{}, cfg, nil)
 
 	fm, err := c.KVsToFeatureMap(kvb)
 	assert.Nil(t, err)

--- a/client/client.go
+++ b/client/client.go
@@ -189,7 +189,9 @@ func (c *Client) UpdateFeatures(bts []byte) {
 	if err != nil {
 		printer.SayErr("parse error: %v, feature payload: %s", err, bts)
 		return
-	}
+	} else (
+		printer.Say(" features updated. features: %s", fm)
+	)
 
 	c.SetFeatureMap(fm)
 }

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -63,11 +63,11 @@ func (w *Watcher) Init() error {
 	if err != nil {
 		return err
 	}
-	
+
 	if err = watcher.Add(w.watchedPath); err != nil {
 		return err
 	}
-	
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.watcher = watcher

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -84,7 +84,7 @@ func (w *Watcher) Watch() {
 				}
 
 				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
-				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)
+				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create) (event.Op&fsnotify.Rename == fsnotify.Rename)
 
 				printer.Say("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
 

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -40,11 +40,11 @@ func New(filepath string) (w *Watcher) {
 		printer.LogErrf("could not start watcher: %v", err)
 		return nil
 	}
-		
+
 	printer.Logf("watching path`: %s", filepath)
 
 	w = &Watcher{
-		path:        filepath,
+		path: filepath,
 	}
 
 	return

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -31,25 +31,25 @@ type Watcher struct {
 }
 
 // New initializes a Watcher and verifies that `path` exists.
-func New(path string) (w *Watcher) {
-	path = strings.TrimSpace(path)
-	watched := path
+func New(filepath string) (w *Watcher) {
+	filepath = strings.TrimSpace(filepath)
+	watched := filepath
 	
-	_, err := os.Stat(watched)
+	_, err := os.Stat(filepath)
 	if err != nil {
 		printer.LogErrf("could not start watcher: %v", err)
 		return nil
 	}
 	
 	// watch the parent directory if it exists
-	if dir, filename := path.Split(watched); dir != "" {
+	if dir, _ := path.Split(filepath); dir != "" {
 		watched = dir
 	}
 	
 	printer.Logf("watching path`: %s", watched)
 
 	w = &Watcher{
-		path: 	     path,
+		path: 	     filepath,
 		watchedPath: watched,
 	}
 

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -72,7 +72,7 @@ func (w *Watcher) Watch() {
 	go func() {
 		for {
 			w.mu.Lock()
-			select {			
+			select {
 			case event := <-w.watcher.Events:
 				printer.LogErrf("received fsnotify event: %v %v", event.Op, event.Name)
 				if event.Op&fsnotify.Write == fsnotify.Write ||

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -84,7 +84,7 @@ func (w *Watcher) Watch() {
 				}
 
 				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
-				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create) (event.Op&fsnotify.Rename == fsnotify.Rename)
+				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)(event.Op&fsnotify.Rename == fsnotify.Rename)
 
 				printer.Say("received fsnotify event: %v %v. Path: %v Correct file: %v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
 

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -31,7 +31,7 @@ type Watcher struct {
 	mu            sync.Mutex
 }
 
-// New initializes a Watcher and verifies that `path` exists.
+// New initializes a Watcher and verifies that `filepath` exists.
 func New(filepath string) (w *Watcher) {
 	filepath = path.Clean(filepath)
 
@@ -40,16 +40,11 @@ func New(filepath string) (w *Watcher) {
 		printer.LogErrf("could not start watcher: %v", err)
 		return nil
 	}
-	
-	//watch the parent dir
-	watched := Dir(filepath)
-	
-	// watch the parent directory if it exists
+		
 	printer.Logf("watching path`: %s", filepath)
 
 	w = &Watcher{
 		path:        filepath,
-		watchedPath: watched,
 	}
 
 	return
@@ -62,8 +57,8 @@ func (w *Watcher) Init() error {
 	if err != nil {
 		return err
 	}
-
-	if err = watcher.Add(w.watchedPath); err != nil {
+	//watch the parent dir
+	if err = watcher.Add(path.Dir(w.path)); err != nil {
 		return err
 	}
 
@@ -98,7 +93,7 @@ func (w *Watcher) Watch() {
 					}
 
 					// Rewatch the path
-					err = w.watcher.Add(w.watchedPath)
+					err = w.watcher.Add(path.Dir(w.path))
 					if err != nil {
 						printer.Err("fsnotify Add error: %v", err)
 					}

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -87,7 +87,7 @@ func (w *Watcher) Watch() {
 				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)
 
 				printer.Info("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
-				
+
 				if correctFile && isWriteEvent {
 					printer.Info("handling fsnotify event: %v %v", event.Op, event.Name)
 					err := w.UpdateBytes()

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -86,7 +86,10 @@ func (w *Watcher) Watch() {
 				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
 				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)
 
+				printer.Info("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
+				
 				if correctFile && isWriteEvent {
+					printer.Info("handling fsnotify event: %v %v", event.Op, event.Name)
 					err := w.UpdateBytes()
 					if err != nil {
 						printer.Err("UpdateBytes error: %v", err)

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -3,7 +3,7 @@ package watcher
 import (
 	"errors"
 	"os"
-
+	"time"
 	"io/ioutil"
 	"sync"
 

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -86,10 +86,10 @@ func (w *Watcher) Watch() {
 				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
 				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)
 
-				printer.Info("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
+				printer.Say("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
 
 				if correctFile && isWriteEvent {
-					printer.Info("handling fsnotify event: %v %v", event.Op, event.Name)
+					printer.Say("handling fsnotify event: %v %v", event.Op, event.Name)
 					err := w.UpdateBytes()
 					if err != nil {
 						printer.Err("UpdateBytes error: %v", err)

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -2,11 +2,12 @@ package watcher
 
 import (
 	"errors"
-	"os"
 	"io/ioutil"
+	"os"
+	"path"
 	"strings"
 	"sync"
-	"path"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/vsco/dcdr/cli/printer"
 )
@@ -34,22 +35,22 @@ type Watcher struct {
 func New(filepath string) (w *Watcher) {
 	filepath = strings.TrimSpace(filepath)
 	watched := filepath
-	
+
 	_, err := os.Stat(filepath)
 	if err != nil {
 		printer.LogErrf("could not start watcher: %v", err)
 		return nil
 	}
-	
+
 	// watch the parent directory if it exists
 	if dir, _ := path.Split(filepath); dir != "" {
 		watched = dir
 	}
-	
+
 	printer.Logf("watching path`: %s", watched)
 
 	w = &Watcher{
-		path: 	     filepath,
+		path:        filepath,
 		watchedPath: watched,
 	}
 
@@ -87,7 +88,7 @@ func (w *Watcher) Watch() {
 				if name != w.path {
 					continue
 				}
-				if event.Op&fsnotify.Write == fsnotify.Write ||					
+				if event.Op&fsnotify.Write == fsnotify.Write ||
 					event.Op&fsnotify.Create == fsnotify.Create ||
 					event.Op&fsnotify.Chmod == fsnotify.Chmod {
 					err := w.UpdateBytes()

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -86,7 +86,7 @@ func (w *Watcher) Watch() {
 				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
 				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create) (event.Op&fsnotify.Rename == fsnotify.Rename)
 
-				printer.Say("received fsnotify event: %v %v. Path: %v Correct file: &v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
+				printer.Say("received fsnotify event: %v %v. Path: %v Correct file: %v, Write: %v", event.Op, event.Name, w.path, correctFile, isWriteEvent)
 
 				if correctFile && isWriteEvent {
 					printer.Say("handling fsnotify event: %v %v", event.Op, event.Name)

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -75,7 +75,7 @@ func (w *Watcher) Watch() {
 			w.mu.Lock()
 			select {
 			case event := <-w.watcher.Events:
-				printer.LogErrf("received fsnotify event: %v", event.Op)
+				printer.LogErrf("received fsnotify event: %v %v", event.Op, event.Name)
 				if event.Op&fsnotify.Write == fsnotify.Write ||
 					event.Op&fsnotify.Create == fsnotify.Create ||
 					event.Op&fsnotify.Chmod == fsnotify.Chmod {

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -33,20 +33,18 @@ type Watcher struct {
 
 // New initializes a Watcher and verifies that `path` exists.
 func New(filepath string) (w *Watcher) {
-	filepath = strings.TrimSpace(filepath)
-	watched := filepath
+	filepath = path.Clean(filepath)
 
 	_, err := os.Stat(filepath)
 	if err != nil {
 		printer.LogErrf("could not start watcher: %v", err)
 		return nil
 	}
-
+	
+	//watch the parent dir
+	watched := Dir(filepath)
+	
 	// watch the parent directory if it exists
-	if dir, _ := path.Split(filepath); dir != "" {
-		watched = dir
-	}
-
 	printer.Logf("watching path`: %s", filepath)
 
 	w = &Watcher{
@@ -90,7 +88,7 @@ func (w *Watcher) Watch() {
 					return
 				}
 
-				correctFile := event.Name != "" && strings.Contains(w.path, event.Name)
+				correctFile := event.Name != "" && strings.Contains(w.path, path.Clean(event.Name))
 				isWriteEvent := (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create)
 
 				if correctFile && isWriteEvent {

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -88,6 +88,8 @@ func (w *Watcher) Watch() {
 					if err != nil {
 						printer.LogErrf("fsnotify Add error: %v", err)
 					}
+				} else {
+					printer.LogErrf("unhandled fsnotify event: %v", event.Op)
 				}
 			case err := <-w.watcher.Errors:
 				printer.LogErrf("watch error: %v", err)

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -3,7 +3,6 @@ package watcher
 import (
 	"errors"
 	"os"
-	"time"
 	"io/ioutil"
 	"sync"
 
@@ -71,19 +70,13 @@ func (w *Watcher) Init() error {
 func (w *Watcher) Watch() {
 	done := make(chan bool)
 	go func() {
-		ticker := time.NewTicker(time.Second * 10)
 		for {
 			w.mu.Lock()
-			select {
-			case <- ticker.C:
-				// Rewatch the path
-				err := w.watcher.Add(w.path)
-				if err != nil {
-					printer.LogErrf("fsnotify Add error: %v", err)
-				}
+			select {			
 			case event := <-w.watcher.Events:
 				printer.LogErrf("received fsnotify event: %v %v", event.Op, event.Name)
 				if event.Op&fsnotify.Write == fsnotify.Write ||
+					event.Op&fsnotify.Remove == fsnotify.Remove ||
 					event.Op&fsnotify.Create == fsnotify.Create ||
 					event.Op&fsnotify.Chmod == fsnotify.Chmod {
 					err := w.UpdateBytes()

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -75,6 +75,7 @@ func (w *Watcher) Watch() {
 			w.mu.Lock()
 			select {
 			case event := <-w.watcher.Events:
+				printer.LogErrf("received fsnotify event: %v", event.Op)
 				if event.Op&fsnotify.Write == fsnotify.Write ||
 					event.Op&fsnotify.Create == fsnotify.Create ||
 					event.Op&fsnotify.Chmod == fsnotify.Chmod {

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -33,7 +33,7 @@ type Watcher struct {
 // New initializes a Watcher and verifies that `path` exists.
 func New(path string) (w *Watcher) {
 	path = strings.TrimSpace(path)
-	watched = path
+	watched := path
 	
 	_, err := os.Stat(watched)
 	if err != nil {

--- a/client/watcher/watcher_test.go
+++ b/client/watcher/watcher_test.go
@@ -59,6 +59,7 @@ func Check(path string, writeF writeFunc, t *testing.T) {
 
 	<-doneChan
 
+	w.Close()
 	err = os.Remove(path)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
On Ubuntu 16.04 (Xenial) there is an issue with `inotify` interpreting the `Rename` syscall (`sys_renameat`) as a `Remove` (`IN_DELETE`). See https://github.com/fsnotify/fsnotify/issues/92#issuecomment-138589622

As a workaround, this patch watches the parent directory for changes instead. It filters out changes to unrelated files.

Downside of this of course, is that directories with large numbers of unrelated files will deliver spurious events to the app. 
Upside is this will work for any flavor of Linux.