### PR TITLE
Switch to maintained version of godspeed

### DIFF
--- a/cli/api/client.go
+++ b/cli/api/client.go
@@ -10,7 +10,7 @@ import (
 
 	"time"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 	"github.com/vsco/dcdr/cli/api/ioutil2"
 	"github.com/vsco/dcdr/cli/api/stores"
 	"github.com/vsco/dcdr/cli/printer"

--- a/client/stats/godspeed/godspeed_statter.go
+++ b/client/stats/godspeed/godspeed_statter.go
@@ -1,6 +1,6 @@
 package stats
 
-import "github.com/PagerDuty/godspeed"
+import "github.com/theckman/godspeed"
 
 // Godspeed stats adapter for Godspeed.
 type Godspeed struct {

--- a/dcdr.go
+++ b/dcdr.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/PagerDuty/godspeed"
+	"github.com/theckman/godspeed"
 	"github.com/vsco/dcdr/cli"
 	"github.com/vsco/dcdr/cli/api"
 	"github.com/vsco/dcdr/cli/api/resolver"

--- a/glide.lock
+++ b/glide.lock
@@ -50,7 +50,7 @@ imports:
   repo: https://github.com/mattn/go-colorable
 - name: github.com/mattn/go-isatty
   version: 56b76bdf51f7708750eac80fa38b952bb9f32639
-- name: github.com/PagerDuty/godspeed
+- name: github.com/theckman/godspeed
   version: ef757b820a7d6760a89641ac29541967eb6d9f05
 - name: github.com/rodaine/table
   version: c35ded4ccfec23e952469a4de8edc168e61c8d58

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   - package: github.com/hashicorp/hcl
   - package: github.com/rodaine/table
   - package: github.com/fatih/color
-  - package: github.com/PagerDuty/godspeed
+  - package: github.com/theckman/godspeed
   - package: github.com/tucnak/climax
   - package: github.com/fsnotify/fsnotify
     ref: v1.3.0


### PR DESCRIPTION
The canonical repository for Godspeed changed back in January 2018.

This change points the `dcdr` dependencies to the new, maintained repo.

See https://github.com/PagerDuty/godspeed/pull/30