### PR TITLE
Avoid config name conflict in client tests

### DIFF
--- a/cli/api/client_test.go
+++ b/cli/api/client_test.go
@@ -137,9 +137,9 @@ func TestKVsToFeatureMapInfoExistByNameSpace(t *testing.T) {
 	}
 
 	cs := stores.NewMockStore(nil, nil)
-	config := config.DefaultConfig()
-	config.Namespace = "diffrent_namespace"
-	c := New(cs, &stores.MockRepo{}, config, nil)
+	cfg := config.DefaultConfig()
+	cfg.Namespace = "diffrent_namespace"
+	c := New(cs, &stores.MockRepo{}, cfg, nil)
 
 	fm, err := c.KVsToFeatureMap(kvb)
 	assert.Nil(t, err)


### PR DESCRIPTION
The client tests have a variable named like one of the imported packages, which makes tests fail on a current run of `docker-compose up --build` with the following error:

```
cli/api/client_test.go:140: declaration of "config" shadows declaration at cli/api/client_test.go:9
```

Renaming the variable to avoid the conflict solves the problem.