### PR TITLE
fixes archlinix build

### DIFF
--- a/Dockerfile.archlinux
+++ b/Dockerfile.archlinux
@@ -1,4 +1,4 @@
-FROM base/archlinux
+FROM archlinux/base
 ADD ./bin/dcdr /usr/bin/dcdr
 ENTRYPOINT ["/usr/bin/dcdr"]
 


### PR DESCRIPTION
Our build is [currently broken](https://travis-ci.org/vsco/dcdr/builds/527218487?utm_source=github_status&utm_medium=notification) due to a bug in our `archlinux` container build step.

This patch fixes the build by moving the base image for this image from [`base/archlinux`](https://hub.docker.com/r/base/archlinux/) to [archlinux/base](https://hub.docker.com/r/archlinux/base) - the currently supported repository 