### PR TITLE
Fix readme reference to Percentiles as Scalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ if dcdr.IsAvailableForID("rollout-new-fancy-db-dual-write", user.Id) {
 ```
 
 #### Scalars
-Scalars have an added bonus: you may use their `float64` values as scalars in certain cases.
+Percentiles have an added bonus: you may use their `float64` values as scalars in certain cases.
 
 Here, we'll use the float value to scale the wait time for DB inserts between 0-1000ms.
 


### PR DESCRIPTION
This is a minor change to the phrasing of the section on scalar values, to highlight the fact that this is a special use case of Percentile features.