### PR TITLE
Use Fallback Poll

### DIFF
--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -2,10 +2,10 @@ package watcher
 
 import (
 	"errors"
-	"os"
-
 	"io/ioutil"
+	"os"
 	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/vsco/dcdr/cli/printer"

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -25,6 +25,8 @@ const watchWaitTime = 5 * time.Second
 
 // Watcher is a wrapper for `fsnotify` that provides the
 // registration of a callback for WRITE events.
+// It uses a 5 second polling fallback to periodically reload dcdr file changes,
+// in the event that the watcher does not fire.
 type Watcher struct {
 	path          string
 	writeCallback func(bts []byte)

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -73,14 +73,14 @@ func (w *Watcher) Init() error {
 
 func (w *Watcher) Watch() {
 	done := make(chan bool)
-	
+
 	timer := time.NewTimer(watchWaitTime)
 	defer timer.Stop()
-	
+
 	go func() {
 		for {
 			timer.Reset(watchWaitTime)
-			
+
 			w.mu.Lock()
 			select {
 			case event := <-w.watcher.Events:
@@ -98,7 +98,7 @@ func (w *Watcher) Watch() {
 						printer.LogErrf("fsnotify Add error: %v", err)
 					}
 				}
-			case <- timer.C:
+			case <-timer.C:
 				err := w.UpdateBytes()
 				if err != nil {
 					printer.LogErrf("UpdateBytes error: %v", err)
@@ -153,3 +153,4 @@ func (w *Watcher) ReadFile() ([]byte, error) {
 
 	return bts, err
 }
+

--- a/client/watcher/watcher.go
+++ b/client/watcher/watcher.go
@@ -153,4 +153,3 @@ func (w *Watcher) ReadFile() ([]byte, error) {
 
 	return bts, err
 }
-


### PR DESCRIPTION
The `fsnotify` based watcher occasionally does not fire some reason, which causes file changes to get ignored.

`fsnotify` has no polling fallback as per: https://github.com/fsnotify/fsnotify/issues/9

Use a 5 second fallback poll, to ensure we see changes eventually.