### PR TITLE
Add syntactic sugar for mock client to set boolean value

### DIFF
--- a/client/mock/mock_client.go
+++ b/client/mock/mock_client.go
@@ -29,16 +29,20 @@ type Client struct {
 	featureMap *models.FeatureMap
 }
 
+// SetBoolFeature set a boolean feature to the provided boolean value
+func (d *Client) SetBoolFeature(feature string, value bool) {
+	d.FeatureMap().Dcdr.Defaults()[feature] = value
+	d.MergeScopes()
+}
+
 // EnableBoolFeature set a boolean feature to true
 func (d *Client) EnableBoolFeature(feature string) {
-	d.FeatureMap().Dcdr.Defaults()[feature] = true
-	d.MergeScopes()
+	d.SetBoolFeature(feature, true)
 }
 
 // DisableBoolFeature set a boolean feature to false
 func (d *Client) DisableBoolFeature(feature string) {
-	d.Client.FeatureMap().Dcdr.Defaults()[feature] = false
-	d.MergeScopes()
+	d.SetBoolFeature(feature, false)
 }
 
 // SetPercentileFeature set a percentile feature to an arbitrary value


### PR DESCRIPTION
### Description
This PR is for a little syntactic sugar in the mock client. I often find I have to do this pattern in unit testing:
```
for _, tt := range tests {
	t.Run(tt.name, func(t *testing.T) {
		d := dcdrMock.New()
		if tt.dcdrSomeFeature {
			d.EnableBoolFeature(dcdrSomeFeature)
		}
		// etc
```

I'd rather simplify this to just always:
```
d.SetBoolFeature(dcdrSomeFeature, tt.dcdrSomeFeature)
```

### Testing
existing units (can add an explicit one for this function if we prefer)