### PR TITLE
Update Issues with Compose Workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,13 @@ services:
     volumes:
       - dcdr:/etc/dcdr
   consul:
-    image: progrium/consul:latest
+    image: consul:latest
     ports:
       - "9400:8400"
       - "9500:8500"
-      - "9600:53/udp"
-    hostname: node1
-    command: -server -bootstrap
+      - "9600:8600"
+      - "9600:8600/udp"
+    command: agent -server -bootstrap -client=0.0.0.0
 volumes:
   dcdr:
     external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     links:
       - consul:consul
     image: dcdr
+    volumes:
+      - dcdr:/etc/dcdr
   dcdr_server:
     environment:
       - "CONSUL_HTTP_ADDR=consul:8500"
@@ -24,6 +26,8 @@ services:
     depends_on:
       - consul
     image: dcdr
+    volumes:
+      - dcdr:/etc/dcdr
   consul:
     image: progrium/consul:latest
     ports:
@@ -32,3 +36,6 @@ services:
       - "9600:53/udp"
     hostname: node1
     command: -server -bootstrap
+volumes:
+  dcdr:
+    external: false

--- a/script/install
+++ b/script/install
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
 
-./script/bootstrap
 ./script/test
 go install


### PR DESCRIPTION
Addressing a number of issues with the "compose" workflow.

1. The `script/bootstrap` command is no longer available so it needs to be removed from `script/install`
2. The `watch` process is not "running" on "dcdr_server" which means that dcdr changes are not propagated to the server API
3. An unsupported / outdated consul image was being used, changed to mainline.

These changes fix the workflow steps and allow users to experience the "Tying the room together" workflow properly.